### PR TITLE
Fix to years(), months(), weeks(), days()

### DIFF
--- a/lib/calendar.js
+++ b/lib/calendar.js
@@ -369,6 +369,20 @@ Calendar.prototype = new (function() {
   {
     return this.events.length;
   };
+  
+  
+  /**
+   * Performs callback on the each of the range.by iterator items
+   * @param {string} interval "week", "day", "year", etc..
+   * @param {DateRange} range DateRange object from moment-range.js
+   * @param {function} callback callback with moment as argument 
+   */
+  this.byFunction = function (interval, range, callback) {
+      var ranges = range.by(interval);
+      for (start of ranges) {
+          callback(start);
+      }
+  };
 
   /**
    * Returns a calendar within a given year
@@ -394,7 +408,7 @@ Calendar.prototype = new (function() {
     var end = this.end.clone().startOf('year');
     var range = moment().range(start, end);
 
-    range.by('years', function(start) {
+    this.byFunction('years', range, function(start) {
       var end = start.clone().endOf('year');
       years.push(self.findInRange(start, end));
     });
@@ -424,7 +438,7 @@ Calendar.prototype = new (function() {
     var end = this.end.clone().startOf('month');
     var range = moment().range(start, end);
 
-    range.by('months', function(start) {
+    this.byFunction('months', range, function(start) {
       var end = start.clone().endOf('month');
       months.push(self.findInRange(start, end));
     });
@@ -454,7 +468,7 @@ Calendar.prototype = new (function() {
     var end = this.end.clone().startOf('week');
     var range = moment().range(start, end);
 
-    range.by('weeks', function(start) {
+    this.byFunction(('weeks', range, function(start) {
       var end = start.clone().endOf('week');
       weeks.push(self.findInRange(start, end));
     });
@@ -484,7 +498,7 @@ Calendar.prototype = new (function() {
     var end = this.end.clone().startOf('day');
     var range = moment().range(start, end);
 
-    range.by('days', function(start) {
+    this.byFunction('days', range, function(start) {
       var end = start.clone().endOf('day');
       days.push(self.findInRange(start, end));
     });

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.4",
   "description": "provides queryable calendar data structure",
   "main": "index.js",
-  "scripts": {
-    "test": "jake test"
-  },
   "repository": {
     "type": "git",
     "url": "git@github.com:der-On/moment-calendar.git"
@@ -21,10 +18,7 @@
   },
   "homepage": "https://github.com/der-On/moment-calendar",
   "dependencies": {
-    "moment": "^2.8.3",
-    "moment-range": "^1.0.5"
-  },
-  "devDependencies": {
-    "jake": "^8.0.10"
+    "moment": "^2.20.1",
+    "moment-range": "^3.1.1"
   }
 }


### PR DESCRIPTION
DateRange.by() function changed parameters from moment-range 3.1.1. Added byFunction to do the same logic with minor changes to code flow.