### PR TITLE
Adding the 'hours' method advertised in the README examples

### DIFF
--- a/lib/calendar.js
+++ b/lib/calendar.js
@@ -492,6 +492,28 @@ Calendar.prototype = new (function() {
   };
 
   /**
+   * Returns a list of calendars ranging over a single hour
+   * @returns Array
+   */
+  this.hours = function()
+  {
+    var self = this;
+    var hours = [];
+    if (!this.start || !this.end) {
+      console.warn('Calendar has no start or end. Please assign them before using days().');
+      return hours;
+    }
+    var start = this.start.clone().startOf('hour');
+    var end = this.end.clone().startOf('hour');
+    var range = moment().range(start, end);
+
+    range.by('hours', function(start) {
+      var end = start.clone().endOf('hour');
+      hours.push(self.findInRange(start, end));
+    });
+    return hours;
+  };
+  /**
    * Returns a list of calendars ranging over all full weeks of a month
    * @param month Number
    * @returns Array


### PR DESCRIPTION
The README.md shows the 'hours' method available:

    ...
    days.forEach(function(day, i) {
      // list of hours within the day
      var hours = day.hours();
     ...

However, it didn't seem to be implemented, so here it is.

Or maybe there is something obvious I missed ?

Cheers